### PR TITLE
add update_interval

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -46,6 +46,7 @@ void to_json(nlohmann::json& j, Config const& config)
             }
         }
         j_server["timeout_dc_ok"] = config.server.timeout_dc_ok;
+        j_server["update_interval"] = config.server.update_interval;
         j_server["send_trajectory"] = config.server.send_trajectory;
         j_server["steps_per_trajectory_frame"] = config.server.steps_per_trajectory_frame;
     }
@@ -84,6 +85,11 @@ void from_json(nlohmann::json const& j, Config & config)
             }
         }
         j_server.at("timeout_dc_ok").get_to(config.server.timeout_dc_ok);
+        if (auto it = j_server.find("update_interval"); it != j_server.end()) {
+            it.value().get_to(config.server.update_interval);
+        } else {
+            config.server.update_interval = std::chrono::milliseconds(0);
+        }
         j_server.at("send_trajectory").get_to(config.server.send_trajectory);
         j_server.at("steps_per_trajectory_frame").get_to(config.server.steps_per_trajectory_frame);
     }

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -36,6 +36,7 @@ struct Config {
     struct Server {
         std::array<unsigned short, 2> port;
         std::chrono::milliseconds timeout_dc_ok;
+        std::chrono::milliseconds update_interval;
         bool send_trajectory;
         size_t steps_per_trajectory_frame;
     } server;

--- a/src/game.hpp
+++ b/src/game.hpp
@@ -80,6 +80,8 @@ private:
     nlohmann::json json_last_move_actual_move_;
     nlohmann::json json_last_move_trajectory_;
 
+    std::optional<std::chrono::steady_clock::time_point> last_update_message_derivery_;
+
     void DoApplyMove(size_t moving_client_id, digitalcurling3::Move && move, std::chrono::milliseconds const& elapsed);
     void DeliverUpdateMessage();
 };


### PR DESCRIPTION
- 高速で通信した際に接続がリセットされる問題に対処するため、updateの頻度を落とせるようにしました。
- 設定ファイルの `server/update_interval` で前回のupdateメッセージから次のupdateメッセージまでの最小時間を設定できます。